### PR TITLE
Enhance netCDF-Java testing

### DIFF
--- a/tests-regression/run_serial_tests.sh
+++ b/tests-regression/run_serial_tests.sh
@@ -431,8 +431,31 @@ if [ "x$RUNJAVA" == "xTRUE" ]; then
     echo -e "o Testing netcdf-java"
     sudo apt update && sudo apt install -y openjdk-${JDKVER}-jdk
     cd ${HOME}/netcdf-java
-    JNA_PATH=${LIBDIR} ./gradlew clean :netcdf4:test
-    ./gradlew clean classes
+
+    GRADLE_OPTS="-DrunSlowTests=True"
+    if [ -d "/share/testdata/cdmUnitTest" ]; then
+        GRADLE_OPTS="${GRADLE_OPTS} -Dunidata.testdata.path=/share/testdata"
+    fi
+
+    # run netCDF-Java tests that rely on the netCDF-C library
+    # and do not trigger trap on failure
+    JNA_PATH=${LIBDIR} ./gradlew ${GRADLE_OPTS} clean :netcdf4:test || true
+
+    if [ -d "/results" ]; then
+        # prepare netCDF-Java results directory
+        if [ -d "/results/netcdf-java" ]; then
+            rm -rf /results/netcdf-java/*
+        else
+            mkdir /results/netcdf-java
+        fi
+        # copy junit test report
+        if [ -f "./netcdf4/build/reports/tests/test/index.html" ]; then
+            cp -r netcdf4/build/reports/tests/test/* /results/netcdf-java
+        fi
+        # copy java error log file if something in the netCDF-C stack trigggers
+        # a core dump
+        find ./netcdf4 -maxdepth 1 -name \*.log -exec cp {} /results/netcdf-java \;
+    fi
     cd ${HOME}
 
 fi


### PR DESCRIPTION
* Use extended test datasets in netcdf4 module testing, if mounted at /share/testdata/cdmUnitTest
* Expose test results under /results/netcdf-java when /results is mounted (including java SIGSEGV crash logs)