### PR TITLE
Reverting to 24.04 to avoid compiler issues

### DIFF
--- a/tests-regression/Dockerfile.nctests
+++ b/tests-regression/Dockerfile.nctests
@@ -4,8 +4,8 @@
 # shared layers that docker provides.
 #####
 #FROM ubuntu:22.04
-#FROM ubuntu:24.04
-FROM ubuntu:25.04
+FROM ubuntu:24.04
+#FROM ubuntu:25.04
 USER root
 ENV HOME=/root
 WORKDIR /root


### PR DESCRIPTION
Reverting to previous LTS to avoid issues at the compiler level that I can't dive into right now. 